### PR TITLE
Prep for 1.0 release

### DIFF
--- a/.github/azure-pipelines/_build.yaml
+++ b/.github/azure-pipelines/_build.yaml
@@ -1,0 +1,14 @@
+# This template is a reusable set of steps that can be shared by multiple CI pipelines.
+#
+# Documentation for this file format is here:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+
+steps:
+  - script: 'git config --local user.email dpreleasebot@hbo.com'
+    displayName: 'git config email'
+  - script: 'git config --local user.name hbo-github-bot'
+    displayName: 'git config name'
+  - script: 'npm install'
+    displayName: 'Install: cleanup-unused-azure-agents'
+  - script: 'npm run coverage'
+    displayName: 'Test: cleanup-unused-azure-agents'

--- a/.github/azure-pipelines/ci-build.yaml
+++ b/.github/azure-pipelines/ci-build.yaml
@@ -25,4 +25,3 @@ steps:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: coverage/*.xml
-      reportDirectory: coverage

--- a/.github/azure-pipelines/ci-build.yaml
+++ b/.github/azure-pipelines/ci-build.yaml
@@ -1,0 +1,28 @@
+# This file defines the CI build steps for this repo.
+#
+# Documentation for this file format is here:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+
+variables:
+  FORCE_COLOR: 1
+pool:
+  vmImage: ubuntu-latest
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 12'
+    inputs:
+      versionSpec: '12.x'
+      checkLatest: true
+  - template: _build.yaml
+  - task: PublishTestResults@2
+    displayName: 'Collect test results'
+    condition: succeededOrFailed()
+    inputs:
+      testRunner: JUnit
+      testResultsFiles: 'junit/*.xml'
+  - task: PublishCodeCoverageResults@1
+    displayName: 'Collect code coverage'
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: coverage/*.xml
+      reportDirectory: coverage

--- a/.github/azure-pipelines/publish.yaml
+++ b/.github/azure-pipelines/publish.yaml
@@ -1,0 +1,21 @@
+# This file defines the CI build steps for this repo.
+#
+# Documentation for this file format is here:
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/yaml-schema
+
+variables:
+  FORCE_COLOR: 1
+pool:
+  vmImage: ubuntu-latest
+steps:
+  - task: NodeTool@0
+    displayName: 'Use Node 12'
+    inputs:
+      versionSpec: '12.x'
+      checkLatest: true
+  - template: _build.yaml
+  - task: Npm@1
+    displayName: 'Publish: cleanup-unused-azure-agents'
+    inputs:
+      command: publish
+      publishEndpoint: 'HBO Public NPM Publishing'

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .nyc_output
 node_modules
+junit
+coverage

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,3 +1,5 @@
 {
-    "file": ["./test/support/setup.js"]
+    "file": ["./test/support/setup.js"],
+    "reporter": "xunit",
+    "reporter-option": "output=junit/results.xml"
 }

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,17 @@
+# Ignore all files by default to prevent accidentally publishing unintended files.
+**
+
+# Use negative patterns to include files.
+# NOTE: These don't need to be specified, because NPM includes them automatically.
+#
+# package.json
+# README (and its variants)
+# CHANGELOG (and its variants)
+# LICENSE / LICENCE
+
+# Entry points
+!index.js
+!cli.js
+
+# Source
+!lib/*.js

--- a/.nycrc.json
+++ b/.nycrc.json
@@ -1,0 +1,8 @@
+{
+  "reporter": [
+    "html",
+    "text",
+    "cobertura"
+  ],
+  "report-dir": "coverage"
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cleanup-unused-azure-agents",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Cleanup unused agents in Azure self-hosted agent pools",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
### SUMMARY

 - Enable pipelines for CI build and publishing
 - Enable unit test and coverage reporting
 - Configure files to release (.npmignore)
 - Bump version to `1.0.0`
